### PR TITLE
Syncing code updates to work without lastTrustedBlock preset

### DIFF
--- a/api/blockchain.py
+++ b/api/blockchain.py
@@ -67,7 +67,9 @@ def storeBlockInDB(block_index, nodeAPI=False):
     success, total_sys, total_net = storeBlockTransactions(block_data)
     if success:
         lastBlock = blockchain_db['blockchain'].find_one({"index": block_data["index"]-1})
-        print(lastBlock)
+        # Comment out below to see the last block, but ojo!, block 0 has some Chinese characters
+        # So make sure your terminal is set to display UTF-8 characters.
+        # print(lastBlock)
         if lastBlock and 'sys_fee' in lastBlock and 'net_fee' in lastBlock:
             block_data['sys_fee'] = lastBlock['sys_fee'] + total_sys
             block_data['net_fee'] = lastBlock['net_fee'] + total_net
@@ -98,19 +100,24 @@ def storeBlockTransactions(block):
         total_net += t['net_fee']
         if 'vin' in t: #t['type'] == 'ContractTransaction':
             input_transaction_data = []
-            for vin in t['vin']:
-                vin['txid'] = convert_txid(vin['txid'])
-                try:
-                    print("trying...")
-                    lookup_t = blockchain_db['transactions'].find_one({"txid": vin['txid']})
-                    # print(lookup_t)
-                    input_transaction_data.append(lookup_t['vout'][vin['vout']])
-                    # print(input_transaction_data)
-                    input_transaction_data[-1]['txid'] = vin['txid']
-                except:
-                    print("failed on transaction lookup")
-                    # print(vin['txid'])
-                    return False, None, None
+
+            # Below we're going to verify that the input transaction (vin) exists in the database
+            # If it doesn't exist, we can't add the transaction
+            # If there is block 0, we skip this check because there's no vins
+            if block["index"] > 0:
+                for vin in t['vin']:
+                    vin['txid'] = convert_txid(vin['txid'])
+                    try:
+                        print("trying...")
+                        lookup_t = blockchain_db['transactions'].find_one({"txid": vin['txid']})
+                        # print(lookup_t)
+                        input_transaction_data.append(lookup_t['vout'][vin['vout']])
+                        # print(input_transaction_data)
+                        input_transaction_data[-1]['txid'] = vin['txid']
+                    except:
+                        print("failed on transaction lookup")
+                        # print(vin['txid'])
+                        return False, None, None
             t['vin_verbose'] = input_transaction_data
         if 'claims' in t:
             claim_transaction_data = []

--- a/init.py
+++ b/init.py
@@ -1,7 +1,4 @@
 from api import blockchain_db, blockchain
 
-# set data to keep track of last fully synced block
-blockchain_db["meta"].insert_one({"name":"lastTrustedBlock", "value":0})
-
 # add required initial nodes data
 blockchain.checkSeeds()


### PR DESCRIPTION
I was having an issue where neon-wallet-db wasn't loading block 0 for me with my private network setup. These changes are an attempt to simplify the initial sync. Now you no longer need to initialize lastTrustedBlock. Also it changes the transaction checking code to ignore that block 0 doesn't have any vins.

Also PR'd here:
https://github.com/CityOfZion/neon-wallet-db/pull/7